### PR TITLE
Overtake fix from newer version of upstream

### DIFF
--- a/addon/infinite/paged-infinite-array.js
+++ b/addon/infinite/paged-infinite-array.js
@@ -73,7 +73,7 @@ var c = InfiniteBase.extend({
   },
 
   then: function(f,f2) {
-    this.get('all').then(f,f2);
+    return this.get('all').then(f,f2);
   }
 });
 

--- a/addon/local/paged-array.js
+++ b/addon/local/paged-array.js
@@ -41,15 +41,20 @@ export default Ember.ArrayProxy.extend(Ember.Evented, {
   then: function(success,failure) {
     var content = Ember.A(this.get('content'));
     var me = this;
+    var promise;
 
     if (content.then) {
-      content.then(function() {
+      promise = content.then(function() {
         success(me);
       },failure);
     }
     else {
-      success(this);
+      promise = new Ember.RSVP.Promise(function(resolve) {
+        resolve(success(me));
+      });
     }
+
+    return promise;
   },
 
   lockToRange: function() {

--- a/addon/remote/paged-remote-array.js
+++ b/addon/remote/paged-remote-array.js
@@ -10,7 +10,7 @@ var ArrayProxyPromiseMixin = Ember.Mixin.create(Ember.PromiseProxyMixin, {
     var promise = this.get('promise');
     var me = this;
 
-    promise.then(function() {
+    return promise.then(function() {
       success(me);
     }, failure);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-pagination",
-  "version": "2.3.1-bayzat",
+  "version": "2.3.2-bayzat",
   "description": "Addon for Ember CLI to do simple pagination. Compatible with the kaminari API in Rails",
   "private": false,
   "directories": {


### PR DESCRIPTION
Cherry-picked commit: [7338b1105212012f3a0a2005df6358a60f1d44b4](https://github.com/mharris717/ember-cli-pagination/commit/7338b1105212012f3a0a2005df6358a60f1d44b4)

I also bumped version to 2.3.2-bayzat, so after merge we just need to tag it.